### PR TITLE
feat: add optional upstream DNS forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ HEALTH_PORT=8080
 
 # Readiness check endpoint port
 READY_PORT=8181
+
+# Upstream DNS server for forwarding unmatched queries (leave empty to disable)
+UPSTREAM_DNS=

--- a/Corefile.template
+++ b/Corefile.template
@@ -1,3 +1,6 @@
+# ABOUTME: CoreDNS configuration template for serving Tailscale machine DNS records.
+# ABOUTME: Environment variables are substituted by entrypoint.sh at container startup.
+
 ${DOMAIN}:${DNS_PORT} {
     tailscale ${DOMAIN}
     cache ${CACHE_TTL}

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ All settings are controlled via environment variables. Copy `.env.example` to `.
 | `CACHE_TTL` | `30` | DNS cache duration in seconds |
 | `HEALTH_PORT` | `8080` | Port for the health check HTTP endpoint |
 | `READY_PORT` | `8181` | Port for the readiness check HTTP endpoint |
+| `UPSTREAM_DNS` | *(empty)* | Upstream DNS server for forwarding unmatched queries (e.g., `1.1.1.1` or `100.100.100.100` for Tailscale MagicDNS). Leave empty to disable forwarding. |
 
 ## Configuring Tailscale split DNS
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -34,6 +34,11 @@ services:
       HEALTH_PORT: ${HEALTH_PORT:-8080}
       READY_PORT: ${READY_PORT:-8181}
 
+      # Upstream DNS server for forwarding unmatched queries.
+      # Leave empty to disable forwarding (split DNS only).
+      # Example: 1.1.1.1 or 100.100.100.100 for Tailscale MagicDNS.
+      UPSTREAM_DNS: ${UPSTREAM_DNS:-}
+
     restart: unless-stopped
 
     healthcheck:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,10 @@ set -e
 
 envsubst < /etc/coredns/Corefile.template > /etc/coredns/Corefile
 
+if [ -n "${UPSTREAM_DNS}" ]; then
+    sed -i '/^}$/i\    forward . '"${UPSTREAM_DNS}" /etc/coredns/Corefile
+fi
+
 echo "Starting CoreDNS with configuration:"
 cat /etc/coredns/Corefile
 echo "---"


### PR DESCRIPTION
## Summary

- Adds `UPSTREAM_DNS` environment variable for optional query forwarding to an upstream DNS server
- When set, the entrypoint script injects a `forward` directive into the CoreDNS Corefile
- When empty (default), nameplate continues to operate as a pure split DNS server with no recursion
- Updated `.env.example`, `docker-compose.example.yml`, and `README.md` with the new option

## Test plan

- [ ] Build and run container with `UPSTREAM_DNS` empty, verify no `forward` directive in Corefile output
- [ ] Build and run container with `UPSTREAM_DNS=1.1.1.1`, verify `forward . 1.1.1.1` appears in Corefile
- [ ] Query a name not in the tailnet with forwarding enabled, verify it resolves via upstream
- [ ] Query a name not in the tailnet with forwarding disabled, verify NXDOMAIN/SERVFAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)