### PR TITLE
ci: exclude docs from release-please

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,6 +4,7 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "simple",
       "include-component-in-tag": false,
+      "exclude-paths": ["docs/", "README.md", "CHANGELOG.md", "*.md"],
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Adds `exclude-paths` to `.release-please-config.json` so commits touching only documentation files (`docs/`, `README.md`, `CHANGELOG.md`, `*.md`) are ignored by release-please
- Since the Docker build job already gates on `release_created == 'true'`, this is sufficient to prevent docs-only merges from triggering image builds

## Test plan
- [ ] Verify release-please does not create a release PR for docs-only commits on main
- [ ] Verify non-docs commits still trigger releases and Docker builds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)