### PR TITLE
build: use Go cross-compilation for multi-platform Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
 
+      # QEMU is only needed for the final alpine stage (apk add),
+      # not for Go compilation which cross-compiles natively.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ABOUTME: Multi-stage build that compiles CoreDNS with the coredns-tailscale plugin.
 # ABOUTME: Produces a minimal image with envsubst for runtime Corefile templating.
 
-FROM golang:1.26-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 ARG COREDNS_VERSION=v1.14.2
 ARG COREDNS_TAILSCALE_VERSION=v0.3.22
@@ -23,13 +23,17 @@ RUN sed -i '/^log:log/a tailscale:github.com/damomurf/coredns-tailscale' plugin.
 # independently of code changes.
 RUN go mod tidy && go mod download
 
-RUN CGO_ENABLED=0 go build -o coredns
+# Cross-compile a binary for each target platform so the Go compiler
+# runs natively on the build host instead of under QEMU.
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o coredns-amd64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o coredns-arm64
 
 FROM alpine:3.23
 
 RUN apk add --no-cache gettext
 
-COPY --from=builder /build/coredns /usr/local/bin/coredns
+ARG TARGETARCH
+COPY --from=builder /build/coredns-${TARGETARCH} /usr/local/bin/coredns
 COPY entrypoint.sh /entrypoint.sh
 COPY Corefile.template /etc/coredns/Corefile.template
 


### PR DESCRIPTION
## Summary

- Pin the builder stage to `$BUILDPLATFORM` so Go runs natively on the CI host instead of under QEMU emulation
- Cross-compile separate amd64 and arm64 binaries, then use `TARGETARCH` in the final stage to copy the correct one
- QEMU is retained only for the lightweight final alpine stage (`apk add`)

## Test plan

- [ ] Trigger a release and verify both `linux/amd64` and `linux/arm64` images are pushed to GHCR
- [ ] Pull each platform image and confirm `coredns --version` runs correctly
- [ ] Compare build times against a previous QEMU-emulated build

🤖 Generated with [Claude Code](https://claude.com/claude-code)