### PR TITLE
build: remove gettext dependency and QEMU from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,6 @@ jobs:
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
 
-      # QEMU is only needed for the final alpine stage (apk add),
-      # not for Go compilation which cross-compiles natively.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ABOUTME: Multi-stage build that compiles CoreDNS with the coredns-tailscale plugin.
-# ABOUTME: Produces a minimal image with envsubst for runtime Corefile templating.
+# ABOUTME: Produces a minimal image with sed-based runtime Corefile templating.
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
@@ -30,14 +30,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o coredns-arm64
 
 FROM alpine:3.23
 
-RUN apk add --no-cache gettext
-
 ARG TARGETARCH
-COPY --from=builder /build/coredns-${TARGETARCH} /usr/local/bin/coredns
-COPY entrypoint.sh /entrypoint.sh
+COPY --chmod=755 --from=builder /build/coredns-${TARGETARCH} /usr/local/bin/coredns
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 COPY Corefile.template /etc/coredns/Corefile.template
-
-RUN chmod +x /entrypoint.sh
 
 EXPOSE 53/tcp 53/udp
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 # ABOUTME: Renders the Corefile template with environment variables and starts CoreDNS.
-# ABOUTME: Runs envsubst to replace placeholders, then execs CoreDNS as PID 1.
+# ABOUTME: Uses sed to replace placeholders, then execs CoreDNS as PID 1.
 
 set -e
 
-envsubst < /etc/coredns/Corefile.template > /etc/coredns/Corefile
+sed \
+    -e "s/\${DOMAIN}/${DOMAIN}/g" \
+    -e "s/\${DNS_PORT}/${DNS_PORT}/g" \
+    -e "s/\${CACHE_TTL}/${CACHE_TTL}/g" \
+    -e "s/\${HEALTH_PORT}/${HEALTH_PORT}/g" \
+    -e "s/\${READY_PORT}/${READY_PORT}/g" \
+    /etc/coredns/Corefile.template > /etc/coredns/Corefile
 
 if [ -n "${UPSTREAM_DNS}" ]; then
     sed -i '/^}$/i\    forward . '"${UPSTREAM_DNS}" /etc/coredns/Corefile


### PR DESCRIPTION
## Summary
- Replace `envsubst` (from `gettext`) with `sed` for Corefile template variable substitution
- Use `COPY --chmod=755` to eliminate all `RUN` commands in the final Docker stage
- Remove QEMU setup step from CI since buildx no longer needs it (no `RUN` commands means no shell execution in the final stage, so no emulation needed)

## Test plan
- [ ] Verify CI builds and pushes multi-arch images successfully without QEMU
- [ ] Run container locally and confirm Corefile variables are substituted correctly
- [ ] Test with `UPSTREAM_DNS` set to confirm forward directive is still injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)