### PR TITLE
build: simplify Dockerfile build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,33 +5,27 @@ FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 ARG COREDNS_VERSION=v1.14.2
 ARG COREDNS_TAILSCALE_VERSION=v0.3.22
+ARG TARGETOS=linux
+ARG TARGETARCH
 
 ENV GOTOOLCHAIN=auto
 
-RUN apk add --no-cache git
-
 WORKDIR /build
 
-RUN git clone --depth 1 --branch ${COREDNS_VERSION} https://github.com/coredns/coredns.git .
+RUN wget -qO- https://github.com/coredns/coredns/archive/refs/tags/${COREDNS_VERSION}.tar.gz | \
+    tar xz --strip-components=1
 
-# Add the tailscale plugin to the plugin list and regenerate imports.
-RUN sed -i '/^log:log/a tailscale:github.com/damomurf/coredns-tailscale' plugin.cfg && \
-    go get github.com/damomurf/coredns-tailscale@${COREDNS_TAILSCALE_VERSION} && \
-    go generate
+COPY plugin.cfg .
 
-# Download dependencies in a separate layer so they are cached
-# independently of code changes.
-RUN go mod tidy && go mod download
+RUN go mod edit -require github.com/damomurf/coredns-tailscale@${COREDNS_TAILSCALE_VERSION} && \
+    go generate && \
+    go mod tidy
 
-# Cross-compile a binary for each target platform so the Go compiler
-# runs natively on the build host instead of under QEMU.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o coredns-amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o coredns-arm64
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o coredns
 
 FROM alpine:3.23
 
-ARG TARGETARCH
-COPY --chmod=755 --from=builder /build/coredns-${TARGETARCH} /usr/local/bin/coredns
+COPY --chmod=755 --from=builder /build/coredns /usr/local/bin/coredns
 COPY --chmod=755 entrypoint.sh /entrypoint.sh
 COPY Corefile.template /etc/coredns/Corefile.template
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -1,0 +1,83 @@
+# ABOUTME: CoreDNS plugin configuration with the tailscale plugin added.
+# ABOUTME: Based on upstream v1.14.2; overlay this onto the CoreDNS source tree before building.
+
+# Directives are registered in the order they should be executed.
+#
+# Ordering is VERY important. Every plugin will feel the effects of all other
+# plugin below (after) them during a request, but they must not care what plugin
+# above them are doing.
+
+# How to rebuild with updated plugin configurations: Modify the list below and
+# run `go generate && go build`
+
+# The parser takes the input format of:
+#
+#     <plugin-name>:<package-name>
+# Or
+#     <plugin-name>:<fully-qualified-package-name>
+#
+# External plugin example:
+#
+# log:github.com/coredns/coredns/plugin/log
+# Local plugin example:
+# log:log
+
+root:root
+metadata:metadata
+geoip:geoip
+cancel:cancel
+tls:tls
+quic:quic
+grpc_server:grpc_server
+https:https
+https3:https3
+timeouts:timeouts
+multisocket:multisocket
+reload:reload
+nsid:nsid
+bufsize:bufsize
+bind:bind
+debug:debug
+trace:trace
+ready:ready
+health:health
+pprof:pprof
+prometheus:metrics
+errors:errors
+log:log
+tailscale:github.com/damomurf/coredns-tailscale
+dnstap:dnstap
+local:local
+dns64:dns64
+any:any
+chaos:chaos
+loadbalance:loadbalance
+tsig:tsig
+cache:cache
+rewrite:rewrite
+acl:acl
+header:header
+dnssec:dnssec
+autopath:autopath
+minimal:minimal
+template:template
+transfer:transfer
+hosts:hosts
+route53:route53
+azure:azure
+clouddns:clouddns
+k8s_external:k8s_external
+kubernetes:kubernetes
+file:file
+auto:auto
+secondary:secondary
+etcd:etcd
+loop:loop
+forward:forward
+grpc:grpc
+erratic:erratic
+whoami:whoami
+on:github.com/coredns/caddy/onevent
+sign:sign
+view:view
+nomad:nomad


### PR DESCRIPTION
## Summary
- Replace `git clone` with GitHub source tarball, dropping the `git` dependency from the builder stage
- Check in `plugin.cfg` instead of patching it with `sed` at build time, making the plugin configuration reviewable and diffable
- Use `go mod edit -require` instead of `go get` for explicit dependency declaration
- Cross-compile only the target architecture instead of building both amd64 and arm64 every time

## Test plan
- [x] `docker build --platform linux/amd64` succeeds
- [ ] `docker build --platform linux/arm64` succeeds
- [ ] Container starts and serves DNS correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)