### PR TITLE
ci: add Docker build validation on PRs and main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+# ABOUTME: CI workflow that validates the Docker image builds successfully.
+# ABOUTME: Runs on pull requests and pushes to main without publishing.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a CI workflow that builds the Docker image on pull requests and pushes to main, catching build failures before release
- Uses `docker/build-push-action` with `push: false` and a single platform (linux/amd64) for fast validation
- Matches existing workflow style (actions/checkout@v6, setup-buildx-action@v4, GHA cache)

Closes #21

## Test plan
- [ ] Verify the CI workflow runs on this PR and the Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)